### PR TITLE
apply button scale before show buttons

### DIFF
--- a/MinimapButtonButton/Logic/Main.lua
+++ b/MinimapButtonButton/Logic/Main.lua
@@ -256,12 +256,21 @@ local function showButtons ()
   buttonContainer:Show();
 end
 
+local function applyButtonScale ()
+  for _, button in ipairs(collectedButtons) do
+    button:SetScale(options.buttonScale);
+  end
+
+  Layout.updateLayout();
+end
+
 local function toggleButtons ()
   collectMinimapButtonsAndUpdateLayout();
 
   if (buttonContainer:IsShown()) then
     hideButtons();
   else
+    applyButtonScale();
     showButtons();
   end
 end
@@ -342,14 +351,6 @@ initFrames();
 
 local function applyScale ()
   mainButton:SetScale(options.scale);
-end
-
-local function applyButtonScale ()
-  for _, button in ipairs(collectedButtons) do
-    button:SetScale(options.buttonScale);
-  end
-
-  Layout.updateLayout();
 end
 
 local function restoreOptions ()


### PR DESCRIPTION
SexyMap [added](https://github.com/funkydude/SexyMap/commit/619c9625ec01cf396a9116316bb3b732e2c027ca) a new option to scale all buttons on the minimap, including `LibDBIcon`.

This is a simple fix: reset the buttons scale before showing the buttons.