### PR TITLE
Add filter input box to button display window

### DIFF
--- a/MinimapButtonButton/Layouts/Gridlayouts.lua
+++ b/MinimapButtonButton/Layouts/Gridlayouts.lua
@@ -1,6 +1,7 @@
 local _, addon = ...;
 
 local ceil = _G.ceil;
+local max = _G.max;
 local min = _G.min;
 local CreateFromMixins = _G.CreateFromMixins;
 
@@ -18,6 +19,25 @@ function GridLayout:updateLayout ()
   self:updateMainButton();
   self:updateButtonContainer();
   self:anchorDisplayedButtons();
+  self:applyFilterVisibility();
+end
+
+function GridLayout:applyFilterVisibility ()
+  local filterActive = Main.getFilterText() ~= '';
+  local anyVisible = false;
+
+  for _, button in ipairs(Main.collectedButtons) do
+    if (button:IsShown()) then
+      local passes = (not filterActive) or Main.passesFilter(button);
+      button:SetAlpha(passes and 1 or 0);
+      if (passes) then anyVisible = true; end
+    end
+  end
+
+  local noMatchLabel = Main.noMatchLabel;
+  if (noMatchLabel) then
+    noMatchLabel:SetShown(filterActive and not anyVisible);
+  end
 end
 
 function GridLayout:updateButtonSizes ()
@@ -67,9 +87,9 @@ end
 
 function GridLayout:calculateButtonContainerSize ()
   local columns, rows = self:calculateGridSize();
-
-  return self:calculateButtonAreaWidth(columns),
-      self:calculateButtonAreaHeight(rows);
+  local width = max(self:calculateButtonAreaWidth(columns), Constants.FILTER_MIN_WIDTH);
+  local height = self:calculateButtonAreaHeight(rows) + Constants.FILTER_AREA_HEIGHT;
+  return width, height;
 end
 
 function GridLayout:anchorDisplayedButtons ()
@@ -101,8 +121,12 @@ function GridLayout:calculateButtonXOffset (column)
 end
 
 function GridLayout:calculateButtonYOffset (row)
-  return (self.buttonHeight + Constants.BUTTON_SPACING) * row +
+  local offset = (self.buttonHeight + Constants.BUTTON_SPACING) * row +
       self.options.innerOffset + self.buttonHeight / 2;
+  if (self.filterAreaOffset) then
+    offset = offset + Constants.FILTER_AREA_HEIGHT;
+  end
+  return offset;
 end
 
 --##############################################################################
@@ -156,6 +180,7 @@ function LeftDownLayout:getButtonAnchor (row, column)
       -self:calculateButtonYOffset(row);
 end
 
+LeftDownLayout.filterAreaOffset = true;
 Layouts.registerLayout('leftdown', LeftDownLayout);
 
 local LeftUpLayout = CreateFromMixins(HorizontalLayout);
@@ -186,6 +211,7 @@ function RightDownLayout:getButtonAnchor (row, column)
       -self:calculateButtonYOffset(row);
 end
 
+RightDownLayout.filterAreaOffset = true;
 Layouts.registerLayout('rightdown', RightDownLayout);
 
 local RightUpLayout = CreateFromMixins(HorizontalLayout);
@@ -246,6 +272,7 @@ function DownLeftLayout:getButtonAnchor (row, column)
       -self:calculateButtonYOffset(column);
 end
 
+DownLeftLayout.filterAreaOffset = true;
 Layouts.registerLayout('downleft', DownLeftLayout);
 
 local DownRightLayout = CreateFromMixins(VerticalLayout);
@@ -261,4 +288,5 @@ function DownRightLayout:getButtonAnchor (row, column)
       -self:calculateButtonYOffset(column);
 end
 
+DownRightLayout.filterAreaOffset = true;
 Layouts.registerLayout('downright', DownRightLayout);

--- a/MinimapButtonButton/Layouts/Gridlayouts.lua
+++ b/MinimapButtonButton/Layouts/Gridlayouts.lua
@@ -29,7 +29,7 @@ function GridLayout:applyFilterVisibility ()
   for _, button in ipairs(Main.collectedButtons) do
     if (button:IsShown()) then
       local passes = (not filterActive) or Main.passesFilter(button);
-      button:SetAlpha(passes and 1 or 0);
+      button:SetAlpha(passes and 1 or Constants.FILTER_DIMMED_ALPHA);
       if (passes) then anyVisible = true; end
     end
   end

--- a/MinimapButtonButton/Layouts/LayoutBase.lua
+++ b/MinimapButtonButton/Layouts/LayoutBase.lua
@@ -17,7 +17,7 @@ function Layout:New (options)
 end
 
 function Layout:isButtonDisplayed (button)
-  return button.IsShown and button:IsShown();
+  return (button.IsShown and button:IsShown());
 end
 
 function Layout:iterateDisplayedButtons (callback)

--- a/MinimapButtonButton/Logic/Constants.lua
+++ b/MinimapButtonButton/Logic/Constants.lua
@@ -22,4 +22,6 @@ addon.export('Logic/Constants', {
   BUTTON_SPACING = 0,
   BUTTON_OFFSET_X = 0,
   BUTTON_OFFSET_Y = -1,
+  FILTER_AREA_HEIGHT = 28,
+  FILTER_MIN_WIDTH = 160,
 });

--- a/MinimapButtonButton/Logic/Constants.lua
+++ b/MinimapButtonButton/Logic/Constants.lua
@@ -24,4 +24,5 @@ addon.export('Logic/Constants', {
   BUTTON_OFFSET_Y = -1,
   FILTER_AREA_HEIGHT = 28,
   FILTER_MIN_WIDTH = 160,
+  FILTER_DIMMED_ALPHA = 0.15,
 });

--- a/MinimapButtonButton/Logic/Main.lua
+++ b/MinimapButtonButton/Logic/Main.lua
@@ -36,8 +36,30 @@ local options;
 local buttonContainer;
 local mainButton;
 local logo;
+local filterBox;
+local noMatchLabel;
+local filterText = '';
 local collectedButtonMap = {};
 local collectedButtons = {};
+
+--##############################################################################
+-- filtering
+--##############################################################################
+
+local function getFilterText ()
+  return filterText;
+end
+
+local function passesFilter (button)
+  if (filterText == '') then return true; end
+  local name = strlower(button:GetName() or '');
+  for word in gmatch(filterText, '%S+') do
+    if (not strfind(name, strlower(word), 1, true)) then
+      return false;
+    end
+  end
+  return true;
+end
 
 --##############################################################################
 -- minimap button collecting
@@ -431,6 +453,78 @@ local function initButtonContainer ()
   buttonContainer:SetScript('OnLeave', checkButtonHover);
 end
 
+local function initFilterBox ()
+  local PADDING = 4;
+
+  filterBox = _G.CreateFrame('EditBox', addonName .. 'FilterBox', buttonContainer,
+      _G.BackdropTemplateMixin and 'BackdropTemplate');
+  filterBox:SetHeight(Constants.FILTER_AREA_HEIGHT - PADDING * 2);
+  filterBox:SetPoint(anchors.TOPLEFT, buttonContainer, anchors.TOPLEFT, PADDING, -PADDING);
+  filterBox:SetPoint(anchors.TOPRIGHT, buttonContainer, anchors.TOPRIGHT, -PADDING, -PADDING);
+  filterBox:SetFontObject(_G.GameFontHighlight);
+  filterBox:SetTextInsets(4, 4, 0, 0);
+  filterBox:SetAutoFocus(false);
+  filterBox:SetMaxLetters(64);
+  filterBox:EnableMouse(true);
+  filterBox:SetFrameLevel(Constants.FRAME_LEVEL + 1);
+
+  if (filterBox.SetBackdrop) then
+    filterBox:SetBackdrop({
+      bgFile = 'Interface/Tooltips/UI-Tooltip-Background',
+      edgeFile = 'Interface/Tooltips/UI-Tooltip-Border',
+      edgeSize = 8,
+      insets = { left = 2, right = 2, top = 2, bottom = 2 },
+    });
+    filterBox:SetBackdropColor(0, 0, 0, 0.5);
+  end
+
+  local placeholder = filterBox:CreateFontString(nil, 'OVERLAY');
+  placeholder:SetPoint(anchors.LEFT, filterBox, anchors.LEFT, 6, 0);
+  placeholder:SetPoint(anchors.RIGHT, filterBox, anchors.RIGHT, -4, 0);
+  local fontPath, fontSize = _G.GameFontHighlight:GetFont();
+  placeholder:SetFont(fontPath, fontSize);
+  placeholder:SetTextColor(0.6, 0.6, 0.6, 1);
+  placeholder:SetJustifyH('LEFT');
+  placeholder:SetText('Filter');
+
+  filterBox:SetScript('OnTextChanged', function (self)
+    filterText = self:GetText();
+    if (filterText == '') then
+      placeholder:Show();
+    else
+      placeholder:Hide();
+    end
+    Layout.updateLayout();
+  end);
+
+  filterBox:SetScript('OnEditFocusGained', function ()
+    placeholder:Hide();
+  end);
+
+  filterBox:SetScript('OnEditFocusLost', function (self)
+    if (self:GetText() == '') then
+      placeholder:Show();
+    end
+  end);
+
+  filterBox:SetScript('OnEscapePressed', function (self)
+    self:SetText('');
+    self:ClearFocus();
+  end);
+
+  filterBox:SetScript('OnEnterPressed', function (self)
+    self:ClearFocus();
+  end);
+
+  noMatchLabel = buttonContainer:CreateFontString(nil, 'OVERLAY', 'GameFontNormal');
+  noMatchLabel:SetText('No buttons match this filter');
+  noMatchLabel:SetPoint(anchors.TOPLEFT, buttonContainer, anchors.TOPLEFT,
+      PADDING, -(Constants.FILTER_AREA_HEIGHT + PADDING));
+  noMatchLabel:SetPoint(anchors.TOPRIGHT, buttonContainer, anchors.TOPRIGHT,
+      -PADDING, -(Constants.FILTER_AREA_HEIGHT + PADDING));
+  noMatchLabel:Hide();
+end
+
 local function initLogo ()
   logo = mainButton:CreateTexture(nil, 'ARTWORK');
   logo:SetTexture('Interface\\AddOns\\' .. addonName ..
@@ -443,6 +537,7 @@ end
 local function initFrames ()
   initMainButton();
   initButtonContainer();
+  initFilterBox();
   initLogo();
 end
 
@@ -564,6 +659,9 @@ addon.export('Logic/Main', {
   mainButton = mainButton,
   logo = logo,
   collectedButtons = collectedButtons,
+  noMatchLabel = noMatchLabel,
+  passesFilter = passesFilter,
+  getFilterText = getFilterText,
   resetPosition = resetPosition,
   applyScale = applyScale,
   hideButtons = hideButtons,

--- a/MinimapButtonButton/Logic/Main.lua
+++ b/MinimapButtonButton/Logic/Main.lua
@@ -456,64 +456,33 @@ end
 local function initFilterBox ()
   local PADDING = 4;
 
+  -- SearchBoxTemplate provides the input border, the magnifying-glass icon, the
+  -- instruction (placeholder) text, and the standard clear button, all managed
+  -- by Blizzard's SearchBoxTemplateMixin.
+  -- InputBoxTemplate (inherited by SearchBoxTemplate) anchors its left border
+  -- texture 5px outside the frame's left edge, so offset the left anchor by that
+  -- overhang to keep the visible border inside the window.
+  local BORDER_OVERHANG = 5;
+
   filterBox = _G.CreateFrame('EditBox', addonName .. 'FilterBox', buttonContainer,
-      _G.BackdropTemplateMixin and 'BackdropTemplate');
+      'SearchBoxTemplate');
   filterBox:SetHeight(Constants.FILTER_AREA_HEIGHT - PADDING * 2);
-  filterBox:SetPoint(anchors.TOPLEFT, buttonContainer, anchors.TOPLEFT, PADDING, -PADDING);
+  filterBox:SetPoint(anchors.TOPLEFT, buttonContainer, anchors.TOPLEFT,
+      PADDING + BORDER_OVERHANG, -PADDING);
   filterBox:SetPoint(anchors.TOPRIGHT, buttonContainer, anchors.TOPRIGHT, -PADDING, -PADDING);
-  filterBox:SetFontObject(_G.GameFontHighlight);
-  filterBox:SetTextInsets(4, 4, 0, 0);
   filterBox:SetAutoFocus(false);
   filterBox:SetMaxLetters(64);
-  filterBox:EnableMouse(true);
   filterBox:SetFrameLevel(Constants.FRAME_LEVEL + 1);
 
-  if (filterBox.SetBackdrop) then
-    filterBox:SetBackdrop({
-      bgFile = 'Interface/Tooltips/UI-Tooltip-Background',
-      edgeFile = 'Interface/Tooltips/UI-Tooltip-Border',
-      edgeSize = 8,
-      insets = { left = 2, right = 2, top = 2, bottom = 2 },
-    });
-    filterBox:SetBackdropColor(0, 0, 0, 0.5);
+  if (filterBox.Instructions) then
+    filterBox.Instructions:SetText('Filter');
   end
 
-  local placeholder = filterBox:CreateFontString(nil, 'OVERLAY');
-  placeholder:SetPoint(anchors.LEFT, filterBox, anchors.LEFT, 6, 0);
-  placeholder:SetPoint(anchors.RIGHT, filterBox, anchors.RIGHT, -4, 0);
-  local fontPath, fontSize = _G.GameFontHighlight:GetFont();
-  placeholder:SetFont(fontPath, fontSize);
-  placeholder:SetTextColor(0.6, 0.6, 0.6, 1);
-  placeholder:SetJustifyH('LEFT');
-  placeholder:SetText('Filter');
-
-  filterBox:SetScript('OnTextChanged', function (self)
+  -- Hooking instead of overriding so the template keeps managing the icon,
+  -- instruction text, and clear button.
+  filterBox:HookScript('OnTextChanged', function (self)
     filterText = self:GetText();
-    if (filterText == '') then
-      placeholder:Show();
-    else
-      placeholder:Hide();
-    end
     Layout.updateLayout();
-  end);
-
-  filterBox:SetScript('OnEditFocusGained', function ()
-    placeholder:Hide();
-  end);
-
-  filterBox:SetScript('OnEditFocusLost', function (self)
-    if (self:GetText() == '') then
-      placeholder:Show();
-    end
-  end);
-
-  filterBox:SetScript('OnEscapePressed', function (self)
-    self:SetText('');
-    self:ClearFocus();
-  end);
-
-  filterBox:SetScript('OnEnterPressed', function (self)
-    self:ClearFocus();
   end);
 
   noMatchLabel = buttonContainer:CreateFontString(nil, 'OVERLAY', 'GameFontNormal');

--- a/MinimapButtonButton/Logic/Main.lua
+++ b/MinimapButtonButton/Logic/Main.lua
@@ -518,10 +518,14 @@ local function initFilterBox ()
 
   noMatchLabel = buttonContainer:CreateFontString(nil, 'OVERLAY', 'GameFontNormal');
   noMatchLabel:SetText('No buttons match this filter');
-  noMatchLabel:SetPoint(anchors.TOPLEFT, buttonContainer, anchors.TOPLEFT,
-      PADDING, -(Constants.FILTER_AREA_HEIGHT + PADDING));
-  noMatchLabel:SetPoint(anchors.TOPRIGHT, buttonContainer, anchors.TOPRIGHT,
-      -PADDING, -(Constants.FILTER_AREA_HEIGHT + PADDING));
+  noMatchLabel:SetJustifyH('CENTER');
+  noMatchLabel:SetJustifyV('MIDDLE');
+  -- Centering within the button area below the filter box: the container center
+  -- is shifted down by half the filter area height to account for that top inset.
+  noMatchLabel:SetPoint(anchors.LEFT, buttonContainer, anchors.LEFT,
+      PADDING, -Constants.FILTER_AREA_HEIGHT / 2);
+  noMatchLabel:SetPoint(anchors.RIGHT, buttonContainer, anchors.RIGHT,
+      -PADDING, -Constants.FILTER_AREA_HEIGHT / 2);
   noMatchLabel:Hide();
 end
 


### PR DESCRIPTION
Thank you for a great addon! I cannot remember the icons for the life of me, so I added this small feature. I hope you like it! I left the icons in the same position to further the cognitive learning of where these addon icons currently are in the grid.

Adds a text input at the top of the button container that filters the collected minimap buttons as the user types.

- Placeholder "Filter" shown in gray, left-aligned, when the box is empty
- Case-insensitive matching; multiple space-separated words must each match a substring of the button name anywhere (e.g. "iT LOOT" matches "Loot It")
- Non-matching buttons are hidden via alpha so the window keeps a stable size and the matching buttons retain their normal grid positions
- Shows "No buttons match this filter" when nothing matches

Generated by Claude Opus. I am an iOS developer for a large company but I don't know much about wow UI. I asked claude to follow existing patterns and localization approaches.
