### PR TITLE
feat: drag-and-drop arrange mode for collected icons

### DIFF
--- a/MinimapButtonButton/Logic/Logic.xml
+++ b/MinimapButtonButton/Logic/Logic.xml
@@ -2,6 +2,7 @@
   <script file="Constants.lua"/>
   <script file="Options.lua"/>
   <script file="Main.lua"/>
+  <script file="Reorder.lua"/>
   <script file="Blacklist.lua"/>
   <script file="Whitelist.lua"/>
 </UI>

--- a/MinimapButtonButton/Logic/Main.lua
+++ b/MinimapButtonButton/Logic/Main.lua
@@ -27,10 +27,12 @@ local Minimap = _G.Minimap;
 
 local LEFTBUTTON = 'LeftButton';
 local MIDDLEBUTTON = 'MiddleButton';
+local RIGHTBUTTON = 'RightButton';
 local ONMOUSEUP = 'OnMouseUp';
 
 local Layout = addon.importPending('Layouts/Main');
 local Blacklist = addon.importPending('Logic/Blacklist');
+local Reorder = addon.importPending('Logic/Reorder');
 local options;
 
 local buttonContainer;
@@ -38,6 +40,7 @@ local mainButton;
 local logo;
 local collectedButtonMap = {};
 local collectedButtons = {};
+local autoCloseSuppressed = false;
 
 --##############################################################################
 -- minimap button collecting
@@ -71,7 +74,7 @@ local function isDescendant (parent, child)
 end
 
 local function checkButtonHover()
-  if (options.autoClose == true) then
+  if (options.autoClose == true and not autoCloseSuppressed) then
     for x, frame in ipairs(GetMouseFoci()) do
       if (isDescendant(buttonContainer, frame) or isDescendant(mainButton, frame)) then
         return;
@@ -347,12 +350,51 @@ local function scanMinimapChildren ()
   end
 end
 
-local function buttonSortFunc (a, b)
-  return ((a:GetName() or '') < (b:GetName() or ''));
+local function buildOrderIndexMap ()
+  local map = {};
+
+  for index, name in ipairs(options.order) do
+    map[name] = index;
+  end
+
+  return map;
 end
 
 local function sortCollectedButtons ()
-  sort(collectedButtons, buttonSortFunc);
+  local orderMap = buildOrderIndexMap();
+
+  sort(collectedButtons, function (a, b)
+    local nameA = a:GetName() or '';
+    local nameB = b:GetName() or '';
+    local indexA = orderMap[nameA];
+    local indexB = orderMap[nameB];
+
+    -- Buttons with a stored position keep their saved order and come before
+    -- any button the user hasn't placed yet, which fall back to alphabetical.
+    if (indexA and indexB) then
+      return indexA < indexB;
+    end
+
+    if (indexA ~= indexB) then
+      return indexA ~= nil;
+    end
+
+    return nameA < nameB;
+  end);
+end
+
+local function persistCurrentOrder ()
+  local order = {};
+
+  for _, button in ipairs(collectedButtons) do
+    local name = button:GetName();
+
+    if (name) then
+      tinsert(order, name);
+    end
+  end
+
+  options.order = order;
 end
 
 local function collectMinimapButtonsAndUpdateLayout ()
@@ -429,6 +471,8 @@ local function initMainButton ()
       moveMainButton();
     elseif (button == LEFTBUTTON) then
       toggleButtons();
+    elseif (button == RIGHTBUTTON) then
+      Reorder.toggle();
     end
   end);
 
@@ -586,6 +630,11 @@ addon.export('Logic/Main', {
   resetPosition = resetPosition,
   applyScale = applyScale,
   hideButtons = hideButtons,
+  showButtons = showButtons,
+  persistCurrentOrder = persistCurrentOrder,
+  setAutoCloseSuppressed = function (value)
+    autoCloseSuppressed = value;
+  end,
   applyButtonScale = applyButtonScale,
   collectMinimapButtonsAndUpdateLayout = collectMinimapButtonsAndUpdateLayout,
   searchButtonByName = searchButtonByName,

--- a/MinimapButtonButton/Logic/Main.lua
+++ b/MinimapButtonButton/Logic/Main.lua
@@ -472,6 +472,7 @@ local function initMainButton ()
     elseif (button == LEFTBUTTON) then
       toggleButtons();
     elseif (button == RIGHTBUTTON) then
+      -- Right-click toggles arrange mode (also available via /mbb arrange).
       Reorder.toggle();
     end
   end);
@@ -525,7 +526,8 @@ end
 local function addDraggingTooltip ()
   Tooltip.createTooltip(mainButton, {
       'You can drag the button using the middle mouse button',
-      'or any mouse button while holding ALT.'
+      'or any mouse button while holding ALT.',
+      'Right-click to arrange the collected icons.'
     });
 end
 

--- a/MinimapButtonButton/Logic/Options.lua
+++ b/MinimapButtonButton/Logic/Options.lua
@@ -3,7 +3,7 @@ local addonName, addon = ...;
 local Events = addon.import('Core/Events');
 local Utils = addon.import('Core/Utils');
 
-local VERSION_COUNTER = 7;
+local VERSION_COUNTER = 8;
 
 local module = addon.export('Logic/Options', {});
 local options = {};
@@ -71,6 +71,7 @@ local function readValues (loadedValues)
       CodexBrowserIcon = true,
     },
     direction = 'leftdown',
+    order = {},
     autoClose = false,
     buttonsPerRow = 5,
     scale = 10,
@@ -92,7 +93,7 @@ local function readValues (loadedValues)
 end
 
 local function printVersionMessage ()
-  Utils.printAddonMessage('now has an option to auto-close the button container!');
+  Utils.printAddonMessage('now lets you rearrange collected icons! Use /mbb arrange to drag them into place.');
 end
 
 local function checkVersion ()

--- a/MinimapButtonButton/Logic/Reorder.lua
+++ b/MinimapButtonButton/Logic/Reorder.lua
@@ -21,6 +21,7 @@ local TARGET_COLOR = {0.2, 1, 0.4, 0.55};
 local active = false;
 local overlays = {};
 local currentTarget;
+local wasShown;
 
 local refreshOverlays;
 
@@ -63,7 +64,9 @@ local function findNearestButton (draggedButton)
   local nearestDistance;
 
   for _, button in ipairs(Main.collectedButtons) do
-    if (button ~= draggedButton and isButtonDisplayed(button)) then
+    -- Only named buttons take part: the saved order is keyed by name, so an
+    -- anonymous button can't be a persistable drop target (see refreshOverlays).
+    if (button ~= draggedButton and isButtonDisplayed(button) and button:GetName()) then
       local centerX, centerY = getScreenCenter(button);
 
       if (centerX) then
@@ -137,8 +140,9 @@ local function createOverlay ()
 
     -- Forward to the button's own handler so the user sees its real tooltip;
     -- fall back to the frame name for buttons that have no tooltip of their own.
+    -- pcall the third-party handler so its error can't bubble through the overlay.
     if (onEnter) then
-      onEnter(button);
+      pcall(onEnter, button);
     else
       GameTooltip:SetOwner(self, 'ANCHOR_RIGHT');
       GameTooltip:SetText(button:GetName() or 'Unnamed button');
@@ -150,7 +154,7 @@ local function createOverlay ()
     local onLeave = self.button:GetScript('OnLeave');
 
     if (onLeave) then
-      onLeave(self.button);
+      pcall(onLeave, self.button);
     end
 
     GameTooltip:Hide();
@@ -196,7 +200,9 @@ function refreshOverlays ()
   end
 
   for _, button in ipairs(Main.collectedButtons) do
-    if (isButtonDisplayed(button)) then
+    -- Skip anonymous buttons: their order can't be persisted (persistCurrentOrder
+    -- / sortCollectedButtons key by name), so don't offer a reorder that won't stick.
+    if (isButtonDisplayed(button) and button:GetName()) then
       local overlay = overlays[button] or createOverlay();
 
       overlays[button] = overlay;
@@ -225,12 +231,24 @@ local function setActive (value)
   Main.setAutoCloseSuppressed(value);
 
   if (value) then
-    Main.showButtons();
+    -- Remember whether the container was already open so exiting arrange mode
+    -- restores the prior state instead of leaving it shown (and persisted).
+    wasShown = Main.buttonContainer:IsShown();
+
+    if (not wasShown) then
+      Main.showButtons();
+    end
+
     refreshOverlays();
     Utils.printAddonMessage(
         'arrange mode ON - drag the icons to reposition them, then run the command again to finish.');
   else
     hideOverlays();
+
+    if (not wasShown) then
+      Main.hideButtons();
+    end
+
     Utils.printAddonMessage('arrange mode OFF.');
   end
 end
@@ -241,7 +259,8 @@ end
 
 SlashCommands.addCommand({'arrange', 'reorder'}, toggle);
 HelpCommands.addHelper({'arrange', 'reorder'},
-    'Toggles arrange mode. While active, drag the collected icons to reposition them; their order is saved. Run the command again to finish.');
+    'Toggles arrange mode. While active, drag the collected icons to reposition ' ..
+    'them; their order is saved. Run the command again to finish.');
 
 module.toggle = toggle;
 module.refreshOverlays = refreshOverlays;

--- a/MinimapButtonButton/Logic/Reorder.lua
+++ b/MinimapButtonButton/Logic/Reorder.lua
@@ -259,8 +259,9 @@ end
 
 SlashCommands.addCommand({'arrange', 'reorder'}, toggle);
 HelpCommands.addHelper({'arrange', 'reorder'},
-    'Toggles arrange mode. While active, drag the collected icons to reposition ' ..
-    'them; their order is saved. Run the command again to finish.');
+    'Toggles arrange mode (also bound to right-clicking the main button). While ' ..
+    'active, drag the collected icons to reposition them; their order is saved. ' ..
+    'Run the command again to finish.');
 
 module.toggle = toggle;
 module.refreshOverlays = refreshOverlays;

--- a/MinimapButtonButton/Logic/Reorder.lua
+++ b/MinimapButtonButton/Logic/Reorder.lua
@@ -1,0 +1,251 @@
+local _, addon = ...;
+
+local ipairs = _G.ipairs;
+local pairs = _G.pairs;
+local CreateFrame = _G.CreateFrame;
+local UIParent = _G.UIParent;
+local GameTooltip = _G.GameTooltip;
+local GetCursorPosition = _G.GetCursorPosition;
+
+local Main = addon.import('Logic/Main');
+local Utils = addon.import('Core/Utils');
+local SlashCommands = addon.import('Core/SlashCommands');
+local HelpCommands = addon.import('Core/HelpCommands');
+local Layout = addon.importPending('Layouts/Main');
+
+local module = addon.export('Logic/Reorder', {});
+
+local HIGHLIGHT_COLOR = {0.2, 0.6, 1, 0.3};
+local TARGET_COLOR = {0.2, 1, 0.4, 0.55};
+
+local active = false;
+local overlays = {};
+local currentTarget;
+
+local refreshOverlays;
+
+--##############################################################################
+-- ordering
+--##############################################################################
+
+local function isButtonDisplayed (button)
+  return button.IsShown and button:IsShown();
+end
+
+-- Center of a frame in absolute screen pixels, so frames at different scales
+-- (the dragged overlay vs. the collected buttons) can be compared directly.
+local function getScreenCenter (frame)
+  local x, y = frame:GetCenter();
+
+  if (x == nil) then
+    return nil;
+  end
+
+  local scale = frame:GetEffectiveScale();
+
+  return x * scale, y * scale;
+end
+
+local function indexOf (list, value)
+  for index, entry in ipairs(list) do
+    if (entry == value) then
+      return index;
+    end
+  end
+
+  return nil;
+end
+
+-- The icon whose center is closest to the cursor (compared in screen pixels).
+local function findNearestButton (draggedButton)
+  local cursorX, cursorY = GetCursorPosition();
+  local nearestButton;
+  local nearestDistance;
+
+  for _, button in ipairs(Main.collectedButtons) do
+    if (button ~= draggedButton and isButtonDisplayed(button)) then
+      local centerX, centerY = getScreenCenter(button);
+
+      if (centerX) then
+        local distance = (centerX - cursorX) ^ 2 + (centerY - cursorY) ^ 2;
+
+        if (nearestDistance == nil or distance < nearestDistance) then
+          nearestDistance = distance;
+          nearestButton = button;
+        end
+      end
+    end
+  end
+
+  return nearestButton;
+end
+
+-- Tints the targeted icon green so the user can see which slot the dragged icon
+-- will drop into before releasing. Restores the previous target's normal tint.
+local function setTarget (button)
+  if (currentTarget == button) then
+    return;
+  end
+
+  if (currentTarget and overlays[currentTarget]) then
+    overlays[currentTarget].highlight:SetColorTexture(unpack(HIGHLIGHT_COLOR));
+  end
+
+  currentTarget = button;
+
+  if (button and overlays[button]) then
+    overlays[button].highlight:SetColorTexture(unpack(TARGET_COLOR));
+  end
+end
+
+local function finishDrag (draggedButton, targetButton)
+  if (targetButton == nil) then
+    return;
+  end
+
+  -- Swap the dragged icon with the highlighted target; every other icon keeps
+  -- its slot.
+  local buttons = Main.collectedButtons;
+  local fromIndex = indexOf(buttons, draggedButton);
+  local toIndex = indexOf(buttons, targetButton);
+
+  buttons[fromIndex] = targetButton;
+  buttons[toIndex] = draggedButton;
+
+  Main.persistCurrentOrder();
+  Layout.updateLayout();
+end
+
+--##############################################################################
+-- drag overlays
+--##############################################################################
+
+local function createOverlay ()
+  local overlay = CreateFrame('Button', nil, Main.buttonContainer);
+
+  overlay:SetMovable(true);
+  overlay:RegisterForDrag('LeftButton');
+
+  local highlight = overlay:CreateTexture(nil, 'OVERLAY');
+  highlight:SetAllPoints(overlay);
+  highlight:SetColorTexture(unpack(HIGHLIGHT_COLOR));
+  overlay.highlight = highlight;
+
+  overlay:SetScript('OnEnter', function (self)
+    local button = self.button;
+    local onEnter = button:GetScript('OnEnter');
+
+    -- Forward to the button's own handler so the user sees its real tooltip;
+    -- fall back to the frame name for buttons that have no tooltip of their own.
+    if (onEnter) then
+      onEnter(button);
+    else
+      GameTooltip:SetOwner(self, 'ANCHOR_RIGHT');
+      GameTooltip:SetText(button:GetName() or 'Unnamed button');
+      GameTooltip:Show();
+    end
+  end);
+
+  overlay:SetScript('OnLeave', function (self)
+    local onLeave = self.button:GetScript('OnLeave');
+
+    if (onLeave) then
+      onLeave(self.button);
+    end
+
+    GameTooltip:Hide();
+  end);
+
+  overlay:SetScript('OnDragStart', function (self)
+    GameTooltip:Hide();
+    self:SetParent(UIParent);
+    self:SetFrameStrata('TOOLTIP');
+    self:StartMoving();
+    self:SetScript('OnUpdate', function ()
+      setTarget(findNearestButton(self.button));
+    end);
+  end);
+
+  overlay:SetScript('OnDragStop', function (self)
+    self:SetScript('OnUpdate', nil);
+    self:StopMovingOrSizing();
+    self:SetParent(Main.buttonContainer);
+
+    local target = currentTarget;
+
+    setTarget(nil);
+    finishDrag(self.button, target);
+    refreshOverlays();
+  end);
+
+  return overlay;
+end
+
+local function hideOverlays ()
+  for _, overlay in pairs(overlays) do
+    overlay:Hide();
+  end
+end
+
+function refreshOverlays ()
+  hideOverlays();
+  currentTarget = nil;
+
+  if (not active) then
+    return;
+  end
+
+  for _, button in ipairs(Main.collectedButtons) do
+    if (isButtonDisplayed(button)) then
+      local overlay = overlays[button] or createOverlay();
+
+      overlays[button] = overlay;
+      overlay.button = button;
+      overlay:SetFrameStrata('HIGH');
+      overlay.highlight:SetColorTexture(unpack(HIGHLIGHT_COLOR));
+      overlay:ClearAllPoints();
+      overlay:SetPoint('CENTER', button, 'CENTER', 0, 0);
+      overlay:SetSize(button:GetWidth() * button:GetScale(),
+          button:GetHeight() * button:GetScale());
+      overlay:Show();
+    end
+  end
+end
+
+--##############################################################################
+-- mode toggle
+--##############################################################################
+
+local function setActive (value)
+  if (active == value) then
+    return;
+  end
+
+  active = value;
+  Main.setAutoCloseSuppressed(value);
+
+  if (value) then
+    Main.showButtons();
+    refreshOverlays();
+    Utils.printAddonMessage(
+        'arrange mode ON - drag the icons to reposition them, then run the command again to finish.');
+  else
+    hideOverlays();
+    Utils.printAddonMessage('arrange mode OFF.');
+  end
+end
+
+local function toggle ()
+  setActive(not active);
+end
+
+SlashCommands.addCommand({'arrange', 'reorder'}, toggle);
+HelpCommands.addHelper({'arrange', 'reorder'},
+    'Toggles arrange mode. While active, drag the collected icons to reposition them; their order is saved. Run the command again to finish.');
+
+module.toggle = toggle;
+module.refreshOverlays = refreshOverlays;
+
+function module.isActive ()
+  return active;
+end

--- a/MinimapButtonButton/Settings/SettingsMenu.lua
+++ b/MinimapButtonButton/Settings/SettingsMenu.lua
@@ -10,6 +10,7 @@ local Main = addon.import('Logic/Main');
 local Options = addon.import('Logic/Options');
 local Enhancements = addon.import('Features/Enhancements');
 local Layout = addon.import('Layouts/Main');
+local Reorder = addon.import('Logic/Reorder');
 
 local addonOptions = Options.getAll();
 
@@ -157,6 +158,10 @@ local function registerSettingsMenu()
       end
     });
   end
+
+  registerButton("Arrange icons", Reorder.toggle, {
+    tooltip = "Toggle arrange mode, then drag the collected icons to reposition them. Their order is saved.",
+  });
 
   registerButton("Reset position", Main.resetPosition);
 


### PR DESCRIPTION
## What

Adds an **arrange mode** that lets users drag the collected icons into a custom order, which persists across reloads.

## Why

Collected icons are sorted alphabetically with no way to influence the order. This lets users put their most-used buttons where they want them.

## How to use

Toggle arrange mode three ways: **right-click** the main button, the `/mbb arrange` command, or the new **"Arrange icons"** button in the settings panel. While active, each icon is tinted and shows its real tooltip on hover. Drag one icon onto another and the two **swap** places; the drop target is highlighted green while dragging. Toggle off when done.

## Implementation notes

- New `Logic/Reorder.lua` plus small hooks; **no change to default display behaviour**.
- Reordering is stored by button name in a new `order` option (`X-NUI`-style backward-compatible migration, `VERSION_COUNTER` bump). An empty order preserves the current alphabetical behaviour, so existing users are unaffected until they arrange something.
- It does **not** move the real buttons (their `SetPoint`/`SetParent` are deliberately stubbed). Instead it overlays transparent drag handles, so there's no taint risk in or out of combat.
- Drag targeting compares frame centers in absolute screen pixels and tracks the dragged icon's own position, so the highlighted target matches what the user sees regardless of grab offset or UI scale.

Happy to adjust naming, the default keybind, or split anything out if you'd prefer a different shape.