### PR TITLE
feat: drag-and-drop arrange mode for collected icons

### DIFF
--- a/MinimapButtonButton/Logic/Logic.xml
+++ b/MinimapButtonButton/Logic/Logic.xml
@@ -2,6 +2,7 @@
   <script file="Constants.lua"/>
   <script file="Options.lua"/>
   <script file="Main.lua"/>
+  <script file="Reorder.lua"/>
   <script file="Blacklist.lua"/>
   <script file="Whitelist.lua"/>
 </UI>

--- a/MinimapButtonButton/Logic/Main.lua
+++ b/MinimapButtonButton/Logic/Main.lua
@@ -27,10 +27,12 @@ local Minimap = _G.Minimap;
 
 local LEFTBUTTON = 'LeftButton';
 local MIDDLEBUTTON = 'MiddleButton';
+local RIGHTBUTTON = 'RightButton';
 local ONMOUSEUP = 'OnMouseUp';
 
 local Layout = addon.importPending('Layouts/Main');
 local Blacklist = addon.importPending('Logic/Blacklist');
+local Reorder = addon.importPending('Logic/Reorder');
 local options;
 
 local buttonContainer;
@@ -38,6 +40,7 @@ local mainButton;
 local logo;
 local collectedButtonMap = {};
 local collectedButtons = {};
+local autoCloseSuppressed = false;
 
 --##############################################################################
 -- minimap button collecting
@@ -71,7 +74,7 @@ local function isDescendant (parent, child)
 end
 
 local function checkButtonHover()
-  if (options.autoClose == true) then
+  if (options.autoClose == true and not autoCloseSuppressed) then
     for x, frame in ipairs(GetMouseFoci()) do
       if (isDescendant(buttonContainer, frame) or isDescendant(mainButton, frame)) then
         return;
@@ -333,12 +336,51 @@ local function scanMinimapChildren ()
   end
 end
 
-local function buttonSortFunc (a, b)
-  return ((a:GetName() or '') < (b:GetName() or ''));
+local function buildOrderIndexMap ()
+  local map = {};
+
+  for index, name in ipairs(options.order) do
+    map[name] = index;
+  end
+
+  return map;
 end
 
 local function sortCollectedButtons ()
-  sort(collectedButtons, buttonSortFunc);
+  local orderMap = buildOrderIndexMap();
+
+  sort(collectedButtons, function (a, b)
+    local nameA = a:GetName() or '';
+    local nameB = b:GetName() or '';
+    local indexA = orderMap[nameA];
+    local indexB = orderMap[nameB];
+
+    -- Buttons with a stored position keep their saved order and come before
+    -- any button the user hasn't placed yet, which fall back to alphabetical.
+    if (indexA and indexB) then
+      return indexA < indexB;
+    end
+
+    if (indexA ~= indexB) then
+      return indexA ~= nil;
+    end
+
+    return nameA < nameB;
+  end);
+end
+
+local function persistCurrentOrder ()
+  local order = {};
+
+  for _, button in ipairs(collectedButtons) do
+    local name = button:GetName();
+
+    if (name) then
+      tinsert(order, name);
+    end
+  end
+
+  options.order = order;
 end
 
 local function collectMinimapButtonsAndUpdateLayout ()
@@ -415,6 +457,8 @@ local function initMainButton ()
       moveMainButton();
     elseif (button == LEFTBUTTON) then
       toggleButtons();
+    elseif (button == RIGHTBUTTON) then
+      Reorder.toggle();
     end
   end);
 
@@ -567,6 +611,11 @@ addon.export('Logic/Main', {
   resetPosition = resetPosition,
   applyScale = applyScale,
   hideButtons = hideButtons,
+  showButtons = showButtons,
+  persistCurrentOrder = persistCurrentOrder,
+  setAutoCloseSuppressed = function (value)
+    autoCloseSuppressed = value;
+  end,
   applyButtonScale = applyButtonScale,
   collectMinimapButtonsAndUpdateLayout = collectMinimapButtonsAndUpdateLayout,
   searchButtonByName = searchButtonByName,

--- a/MinimapButtonButton/Logic/Options.lua
+++ b/MinimapButtonButton/Logic/Options.lua
@@ -3,7 +3,7 @@ local addonName, addon = ...;
 local Events = addon.import('Core/Events');
 local Utils = addon.import('Core/Utils');
 
-local VERSION_COUNTER = 7;
+local VERSION_COUNTER = 8;
 
 local module = addon.export('Logic/Options', {});
 local options = {};
@@ -71,6 +71,7 @@ local function readValues (loadedValues)
       CodexBrowserIcon = true,
     },
     direction = 'leftdown',
+    order = {},
     autoClose = false,
     buttonsPerRow = 5,
     scale = 10,
@@ -92,7 +93,7 @@ local function readValues (loadedValues)
 end
 
 local function printVersionMessage ()
-  Utils.printAddonMessage('now has an option to auto-close the button container!');
+  Utils.printAddonMessage('now lets you rearrange collected icons! Use /mbb arrange to drag them into place.');
 end
 
 local function checkVersion ()

--- a/MinimapButtonButton/Logic/Reorder.lua
+++ b/MinimapButtonButton/Logic/Reorder.lua
@@ -1,0 +1,251 @@
+local _, addon = ...;
+
+local ipairs = _G.ipairs;
+local pairs = _G.pairs;
+local CreateFrame = _G.CreateFrame;
+local UIParent = _G.UIParent;
+local GameTooltip = _G.GameTooltip;
+local GetCursorPosition = _G.GetCursorPosition;
+
+local Main = addon.import('Logic/Main');
+local Utils = addon.import('Core/Utils');
+local SlashCommands = addon.import('Core/SlashCommands');
+local HelpCommands = addon.import('Core/HelpCommands');
+local Layout = addon.importPending('Layouts/Main');
+
+local module = addon.export('Logic/Reorder', {});
+
+local HIGHLIGHT_COLOR = {0.2, 0.6, 1, 0.3};
+local TARGET_COLOR = {0.2, 1, 0.4, 0.55};
+
+local active = false;
+local overlays = {};
+local currentTarget;
+
+local refreshOverlays;
+
+--##############################################################################
+-- ordering
+--##############################################################################
+
+local function isButtonDisplayed (button)
+  return button.IsShown and button:IsShown();
+end
+
+-- Center of a frame in absolute screen pixels, so frames at different scales
+-- (the dragged overlay vs. the collected buttons) can be compared directly.
+local function getScreenCenter (frame)
+  local x, y = frame:GetCenter();
+
+  if (x == nil) then
+    return nil;
+  end
+
+  local scale = frame:GetEffectiveScale();
+
+  return x * scale, y * scale;
+end
+
+local function indexOf (list, value)
+  for index, entry in ipairs(list) do
+    if (entry == value) then
+      return index;
+    end
+  end
+
+  return nil;
+end
+
+-- The icon whose center is closest to the cursor (compared in screen pixels).
+local function findNearestButton (draggedButton)
+  local cursorX, cursorY = GetCursorPosition();
+  local nearestButton;
+  local nearestDistance;
+
+  for _, button in ipairs(Main.collectedButtons) do
+    if (button ~= draggedButton and isButtonDisplayed(button)) then
+      local centerX, centerY = getScreenCenter(button);
+
+      if (centerX) then
+        local distance = (centerX - cursorX) ^ 2 + (centerY - cursorY) ^ 2;
+
+        if (nearestDistance == nil or distance < nearestDistance) then
+          nearestDistance = distance;
+          nearestButton = button;
+        end
+      end
+    end
+  end
+
+  return nearestButton;
+end
+
+-- Tints the targeted icon green so the user can see which slot the dragged icon
+-- will drop into before releasing. Restores the previous target's normal tint.
+local function setTarget (button)
+  if (currentTarget == button) then
+    return;
+  end
+
+  if (currentTarget and overlays[currentTarget]) then
+    overlays[currentTarget].highlight:SetColorTexture(unpack(HIGHLIGHT_COLOR));
+  end
+
+  currentTarget = button;
+
+  if (button and overlays[button]) then
+    overlays[button].highlight:SetColorTexture(unpack(TARGET_COLOR));
+  end
+end
+
+local function finishDrag (draggedButton, targetButton)
+  if (targetButton == nil) then
+    return;
+  end
+
+  -- Swap the dragged icon with the highlighted target; every other icon keeps
+  -- its slot.
+  local buttons = Main.collectedButtons;
+  local fromIndex = indexOf(buttons, draggedButton);
+  local toIndex = indexOf(buttons, targetButton);
+
+  buttons[fromIndex] = targetButton;
+  buttons[toIndex] = draggedButton;
+
+  Main.persistCurrentOrder();
+  Layout.updateLayout();
+end
+
+--##############################################################################
+-- drag overlays
+--##############################################################################
+
+local function createOverlay ()
+  local overlay = CreateFrame('Button', nil, Main.buttonContainer);
+
+  overlay:SetMovable(true);
+  overlay:RegisterForDrag('LeftButton');
+
+  local highlight = overlay:CreateTexture(nil, 'OVERLAY');
+  highlight:SetAllPoints(overlay);
+  highlight:SetColorTexture(unpack(HIGHLIGHT_COLOR));
+  overlay.highlight = highlight;
+
+  overlay:SetScript('OnEnter', function (self)
+    local button = self.button;
+    local onEnter = button:GetScript('OnEnter');
+
+    -- Forward to the button's own handler so the user sees its real tooltip;
+    -- fall back to the frame name for buttons that have no tooltip of their own.
+    if (onEnter) then
+      onEnter(button);
+    else
+      GameTooltip:SetOwner(self, 'ANCHOR_RIGHT');
+      GameTooltip:SetText(button:GetName() or 'Unnamed button');
+      GameTooltip:Show();
+    end
+  end);
+
+  overlay:SetScript('OnLeave', function (self)
+    local onLeave = self.button:GetScript('OnLeave');
+
+    if (onLeave) then
+      onLeave(self.button);
+    end
+
+    GameTooltip:Hide();
+  end);
+
+  overlay:SetScript('OnDragStart', function (self)
+    GameTooltip:Hide();
+    self:SetParent(UIParent);
+    self:SetFrameStrata('TOOLTIP');
+    self:StartMoving();
+    self:SetScript('OnUpdate', function ()
+      setTarget(findNearestButton(self.button));
+    end);
+  end);
+
+  overlay:SetScript('OnDragStop', function (self)
+    self:SetScript('OnUpdate', nil);
+    self:StopMovingOrSizing();
+    self:SetParent(Main.buttonContainer);
+
+    local target = currentTarget;
+
+    setTarget(nil);
+    finishDrag(self.button, target);
+    refreshOverlays();
+  end);
+
+  return overlay;
+end
+
+local function hideOverlays ()
+  for _, overlay in pairs(overlays) do
+    overlay:Hide();
+  end
+end
+
+function refreshOverlays ()
+  hideOverlays();
+  currentTarget = nil;
+
+  if (not active) then
+    return;
+  end
+
+  for _, button in ipairs(Main.collectedButtons) do
+    if (isButtonDisplayed(button)) then
+      local overlay = overlays[button] or createOverlay();
+
+      overlays[button] = overlay;
+      overlay.button = button;
+      overlay:SetFrameStrata('HIGH');
+      overlay.highlight:SetColorTexture(unpack(HIGHLIGHT_COLOR));
+      overlay:ClearAllPoints();
+      overlay:SetPoint('CENTER', button, 'CENTER', 0, 0);
+      overlay:SetSize(button:GetWidth() * button:GetScale(),
+          button:GetHeight() * button:GetScale());
+      overlay:Show();
+    end
+  end
+end
+
+--##############################################################################
+-- mode toggle
+--##############################################################################
+
+local function setActive (value)
+  if (active == value) then
+    return;
+  end
+
+  active = value;
+  Main.setAutoCloseSuppressed(value);
+
+  if (value) then
+    Main.showButtons();
+    refreshOverlays();
+    Utils.printAddonMessage(
+        'arrange mode ON - drag the icons to reposition them, then run the command again to finish.');
+  else
+    hideOverlays();
+    Utils.printAddonMessage('arrange mode OFF.');
+  end
+end
+
+local function toggle ()
+  setActive(not active);
+end
+
+SlashCommands.addCommand({'arrange', 'reorder'}, toggle);
+HelpCommands.addHelper({'arrange', 'reorder'},
+    'Toggles arrange mode. While active, drag the collected icons to reposition them; their order is saved. Run the command again to finish.');
+
+module.toggle = toggle;
+module.refreshOverlays = refreshOverlays;
+
+function module.isActive ()
+  return active;
+end

--- a/MinimapButtonButton/Settings/SettingsMenu.lua
+++ b/MinimapButtonButton/Settings/SettingsMenu.lua
@@ -10,6 +10,7 @@ local Main = addon.import('Logic/Main');
 local Options = addon.import('Logic/Options');
 local Enhancements = addon.import('Features/Enhancements');
 local Layout = addon.import('Layouts/Main');
+local Reorder = addon.import('Logic/Reorder');
 
 local addonOptions = Options.getAll();
 
@@ -157,6 +158,10 @@ local function registerSettingsMenu()
       end
     });
   end
+
+  registerButton("Arrange icons", Reorder.toggle, {
+    tooltip = "Toggle arrange mode, then drag the collected icons to reposition them. Their order is saved.",
+  });
 
   registerButton("Reset position", Main.resetPosition);
 


### PR DESCRIPTION
Adds an arrange mode (right-click the main button, /mbb arrange, or the "Arrange icons" settings button) that overlays draggable handles on the collected icons. Dragging one onto another swaps the two; the target is highlighted green while dragging, and hovering forwards each button's own tooltip. The chosen order is saved to a new `order` option and applied on every sort, so icons keep their positions across reloads.

No change to default display behaviour.